### PR TITLE
Fix PHPUnit < 5.4 compatibility

### DIFF
--- a/bin/phpchunkit
+++ b/bin/phpchunkit
@@ -52,10 +52,12 @@ $autoloaderPath = (new AutoloaderFinder())
 
 require_once $autoloaderPath;
 
-(new PHPChunkit(getcwd(), new Container()))
+$exitCode =(new PHPChunkit(getcwd(), new Container()))
     ->getContainer()['phpchunkit.application']
     ->run(
         new ArgvInput(),
         new ConsoleOutput()
     )
 ;
+
+exit($exitCode);

--- a/src/PHPChunkitApplication.php
+++ b/src/PHPChunkitApplication.php
@@ -42,6 +42,7 @@ class PHPChunkitApplication
     {
         $this->container = $container;
         $this->symfonyApplication = $this->container['phpchunkit.symfony_application'];
+        $this->symfonyApplication->setAutoExit(false);
     }
 
     public function run(InputInterface $input, OutputInterface $output) : int
@@ -74,7 +75,7 @@ class PHPChunkitApplication
                 }
             }
 
-            call_user_func_array([$service, 'execute'], [$input, $output]);
+            return call_user_func_array([$service, 'execute'], [$input, $output]);
         });
     }
 

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -29,4 +29,24 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
     {
         return realpath(__DIR__.'/../tests');
     }
+
+    /**
+     * PHPUnit 5.x compat, see createMock vs getMock
+     *
+     * @param string $originalClassName
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($originalClassName)
+    {
+        $builder = $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning();
+
+        if (method_exists($builder, 'disallowMockingUnknownTypes')) {
+            $builder->disallowMockingUnknownTypes();
+        }
+
+        return $builder->getMock();
+    }
 }

--- a/tests/Command/SetupTest.php
+++ b/tests/Command/SetupTest.php
@@ -3,12 +3,12 @@
 namespace PHPChunkit\Test\Command;
 
 use PHPChunkit\Command\Setup;
-use PHPUnit_Framework_TestCase;
+use PHPChunkit\Test\BaseTest;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 
-class SetupTest extends PHPUnit_Framework_TestCase
+class SetupTest extends BaseTest
 {
     /**
      * @var Setup

--- a/tests/GenerateTestClassTest.php
+++ b/tests/GenerateTestClassTest.php
@@ -146,7 +146,32 @@ EOF;
 
     public function testGenerateAdvancedClass()
     {
+        try {
+            new \ReflectionMethod(\PHPUnit_Framework_TestCase::class, 'createMock');
+        } catch (\ReflectionException $e) {
+            $this->markTestSkipped('PHPUnit >= 5.4 is required.');
+        }
+
         $this->checkGeneratedTestClass(self::EXPECTED_ADVANCED_CLASS, TestAdvancedClass::class);
+
+        $test = new \PHPChunkit\Test\TestAdvancedClassTest();
+        $test->setUp();
+        $test->testGetSomething1();
+        $test->testGetSomething2();
+    }
+
+    public function testGenerateAdvancedClassPHPUnitCompat()
+    {
+        try {
+            new \ReflectionMethod(\PHPUnit_Framework_TestCase::class, 'createMock');
+            $this->markTestSkipped('PHPUnit < 5.4 is required.');
+        } catch (\ReflectionException $e) {
+        }
+
+        $this->checkGeneratedTestClass(
+            str_replace('createMock', 'getMock', self::EXPECTED_ADVANCED_CLASS),
+            TestAdvancedClass::class
+        );
 
         $test = new \PHPChunkit\Test\TestAdvancedClassTest();
         $test->setUp();


### PR DESCRIPTION
- Fix PHPUnit < 5.4 compatibility
- Fix missing exit code for phpchunkit binary, caused travis to pass with failed tests

```
FAILED (3 chunks, 60 tests, 67 assertions, 17 failures, Failed chunks: 2)
~/w/phpchunkit (patch-1|✚1…) $ echo $status
1
```