### PR TITLE
Fix phpunit/phpunit-mock-objects compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
 before_script:
   - phpenv config-rm xdebug.ini || true
   - composer self-update
-  - composer require phpunit/phpunit:${PHPUNIT} --no-update
   - composer update ${COMPOSER_OPTS}
+  - composer require phpunit/phpunit:${PHPUNIT} ${COMPOSER_OPTS}
   - git config --global user.name travis-ci
   - git config --global user.email travis@example.com
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
 before_script:
   - phpenv config-rm xdebug.ini || true
   - composer self-update
-  - composer update ${COMPOSER_OPTS}
   - composer require phpunit/phpunit:${PHPUNIT} ${COMPOSER_OPTS}
   - git config --global user.name travis-ci
   - git config --global user.email travis@example.com

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=7.0.0",
         "phpunit/phpunit": "^5.0",
         "phpunit/phpunit-mock-objects": "^3.1",
+        "sebastian/comparator": "^1.2",
         "symfony/console": "^2.7|^3.0",
         "symfony/process": "^2.7|^3.0",
         "symfony/stopwatch": "^2.7|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.0.0",
         "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit-mock-objects": "^3.1",
         "symfony/console": "^2.7|^3.0",
         "symfony/process": "^2.7|^3.0",
         "symfony/stopwatch": "^2.7|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.0.0",
         "phpunit/phpunit": "^5.0",
         "phpunit/phpunit-mock-objects": "^3.1",
-        "sebastian/comparator": "^1.2.1",
+        "sebastian/comparator": "^1.2.3",
         "symfony/console": "^2.7|^3.0",
         "symfony/process": "^2.7|^3.0",
         "symfony/stopwatch": "^2.7|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.0.0",
         "phpunit/phpunit": "^5.0",
         "phpunit/phpunit-mock-objects": "^3.1",
-        "sebastian/comparator": "^1.2",
+        "sebastian/comparator": "^1.2.1",
         "symfony/console": "^2.7|^3.0",
         "symfony/process": "^2.7|^3.0",
         "symfony/stopwatch": "^2.7|^3.0",


### PR DESCRIPTION
Fatal error: Declaration of Mock_Configuration_ee67cdc8::createFromXmlFile(string $path): Mock_Configuration_ee67cdc8 must be compatible with PHPChunkit\Configuration::createFromXmlFile(string $path)